### PR TITLE
fix/python 3.14 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v6.4 (Planned):
+- **Python 3.14+ Compatibility:** Added a shim for `pkg_resources` to ensure compatibility with legacy dependencies (like `autosubsync`) that fail in recent Python versions where `setuptools` is not installed by default.
+- Updated `pyproject.toml` to allow installation on Python 3.14.
+
 v6.3 only includes the following changes on top of v6.2:
 - Added new language: zh_TW (Traditional Chinese, Taiwan) contributed by [@ceshizhuanyong895](https://github.com/ceshizhuanyong895) in [#68](https://github.com/denizsafak/AutoSubSync/pull/68).
 - Fixed an issue where the application would not restart correctly, due to incorrect handling of entry points in the `restart_application` function. Improved error logging to provide clearer information if a restart fails in the future.

--- a/main/call_autosubsync.py
+++ b/main/call_autosubsync.py
@@ -5,6 +5,31 @@ import logging
 from multiprocessing import freeze_support
 from utils import get_resource_path
 
+# Shim for pkg_resources (removed in Python 3.14+)
+try:
+    import pkg_resources
+except ImportError:
+    import types
+    from pathlib import Path
+
+    # Create a dummy pkg_resources module to satisfy legacy dependencies
+    pkg_resources_shim = types.ModuleType("pkg_resources")
+
+    def resource_filename(package_or_requirement, resource_name):
+        """
+        Implementation of resource_filename for legacy libraries (like autosubsync).
+        """
+        try:
+            module = sys.modules.get(package_or_requirement)
+            if module and hasattr(module, "__file__"):
+                return str(Path(module.__file__).parent / resource_name)
+        except Exception:
+            pass
+        return resource_name
+
+    pkg_resources_shim.resource_filename = resource_filename
+    sys.modules["pkg_resources"] = pkg_resources_shim
+
 # Monkey-patch subprocess.Popen to always use CREATE_NO_WINDOW on Windows
 import subprocess
 

--- a/main/call_autosubsync.py
+++ b/main/call_autosubsync.py
@@ -4,33 +4,10 @@ import runpy, os, threading
 import logging
 from multiprocessing import freeze_support
 from utils import get_resource_path
+import compat  # Shim for pkg_resources (removed in Python 3.14+)
 
-# Shim for pkg_resources (removed in Python 3.14+)
-try:
-    import pkg_resources
-except ImportError:
-    import types
-    from pathlib import Path
-
-    # Create a dummy pkg_resources module to satisfy legacy dependencies
-    pkg_resources_shim = types.ModuleType("pkg_resources")
-
-    def resource_filename(package_or_requirement, resource_name):
-        """
-        Implementation of resource_filename for legacy libraries (like autosubsync).
-        """
-        try:
-            module = sys.modules.get(package_or_requirement)
-            if module and hasattr(module, "__file__"):
-                return str(Path(module.__file__).parent / resource_name)
-        except Exception:
-            pass
-        return resource_name
-
-    pkg_resources_shim.resource_filename = resource_filename
-    sys.modules["pkg_resources"] = pkg_resources_shim
-
-# Monkey-patch subprocess.Popen to always use CREATE_NO_WINDOW on Windows
+# Monkey-patch subprocess.Popen
+ to always use CREATE_NO_WINDOW on Windows
 import subprocess
 
 if platform.system() == "Windows":

--- a/main/compat.py
+++ b/main/compat.py
@@ -1,0 +1,30 @@
+import sys
+import types
+from pathlib import Path
+
+"""
+Compatibility layer for AutoSubSync.
+Handles shims for deprecated or removed features in newer Python versions.
+"""
+
+# Shim for pkg_resources (removed in Python 3.14+)
+try:
+    import pkg_resources
+except ImportError:
+    # Create a dummy pkg_resources module to satisfy legacy dependencies
+    pkg_resources_shim = types.ModuleType("pkg_resources")
+
+    def resource_filename(package_or_requirement, resource_name):
+        """
+        Implementation of resource_filename for legacy libraries (like autosubsync).
+        """
+        try:
+            module = sys.modules.get(package_or_requirement)
+            if module and hasattr(module, "__file__") and module.__file__:
+                return str(Path(module.__file__).parent / resource_name)
+        except Exception:
+            pass
+        return resource_name
+
+    pkg_resources_shim.resource_filename = resource_filename
+    sys.modules["pkg_resources"] = pkg_resources_shim

--- a/main/main.py
+++ b/main/main.py
@@ -4,6 +4,31 @@ import platform
 import logging
 import multiprocessing
 
+# Shim for pkg_resources (removed in Python 3.14+)
+try:
+    import pkg_resources
+except ImportError:
+    import types
+    from pathlib import Path
+
+    # Create a dummy pkg_resources module to satisfy legacy dependencies
+    pkg_resources_shim = types.ModuleType("pkg_resources")
+
+    def resource_filename(package_or_requirement, resource_name):
+        """
+        Implementation of resource_filename for legacy libraries (like autosubsync).
+        """
+        try:
+            module = sys.modules.get(package_or_requirement)
+            if module and hasattr(module, "__file__"):
+                return str(Path(module.__file__).parent / resource_name)
+        except Exception:
+            pass
+        return resource_name
+
+    pkg_resources_shim.resource_filename = resource_filename
+    sys.modules["pkg_resources"] = pkg_resources_shim
+
 # Fix multiprocessing for installed packages:
 # - On Linux: use 'fork' to avoid re-importing the 'main' module (which conflicts with our package name)
 # - On Windows/macOS: 'fork' is unavailable or unsafe, so we rely on freeze_support()

--- a/main/main.py
+++ b/main/main.py
@@ -3,31 +3,7 @@ import sys
 import platform
 import logging
 import multiprocessing
-
-# Shim for pkg_resources (removed in Python 3.14+)
-try:
-    import pkg_resources
-except ImportError:
-    import types
-    from pathlib import Path
-
-    # Create a dummy pkg_resources module to satisfy legacy dependencies
-    pkg_resources_shim = types.ModuleType("pkg_resources")
-
-    def resource_filename(package_or_requirement, resource_name):
-        """
-        Implementation of resource_filename for legacy libraries (like autosubsync).
-        """
-        try:
-            module = sys.modules.get(package_or_requirement)
-            if module and hasattr(module, "__file__"):
-                return str(Path(module.__file__).parent / resource_name)
-        except Exception:
-            pass
-        return resource_name
-
-    pkg_resources_shim.resource_filename = resource_filename
-    sys.modules["pkg_resources"] = pkg_resources_shim
+import compat  # Shim for pkg_resources (removed in Python 3.14+)
 
 # Fix multiprocessing for installed packages:
 # - On Linux: use 'fork' to avoid re-importing the 'main' module (which conflicts with our package name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 readme = "README.md"
 license = "GPL-3.0-or-later"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 keywords = [
     "subtitle",
     "synchronization",


### PR DESCRIPTION
### Description
This PR ensures compatibility with Python 3.14+ by addressing the removal of `pkg_resources` (from `setuptools`), which previously caused the application to fail when calling the `autosubsync` library.

### Key Changes
- **Added `main/compat.py`**: Introduced a dedicated compatibility layer that implements a shim for `pkg_resources.resource_filename`. This cleanly supports legacy dependencies relying on deprecated APIs.
- **Centralized Logic (DRY)**: Instead of duplicating the shim, it is now centralized in `compat.py` and imported by `main.py` and `call_autosubsync.py`, improving codebase maintainability.
- **Python 3.14 Readiness**: Updated `pyproject.toml` to remove the `<3.14` version constraint, officially allowing the tool to run on the latest Python environments.
- **Documentation**: Updated the `CHANGELOG` to reflect these compatibility improvements.

### Technical Note
The shim handles path resolution for the `trained-model.bin` required by the underlying synchronization engine. It uses a robust `pathlib` approach while maintaining a fully transparent interface for the legacy library.