### PR TITLE
feat: add option to disable ALASS rename prompt

### DIFF
--- a/main/constants.py
+++ b/main/constants.py
@@ -148,6 +148,7 @@ DEFAULT_OPTIONS = {
     "theme": "system",
     "skip_previously_processed_videos": True,
     "auto_rename_bracket_paths": False,
+    "disable_alass_rename_prompt": False,
 }
 
 # ffmpeg and ffprobe paths

--- a/main/sync_auto.py
+++ b/main/sync_auto.py
@@ -213,6 +213,13 @@ def _ask_rename_for_alass(app):
         )
     )
     layout.addWidget(remember_box)
+
+    dont_ask_again_box = QCheckBox(texts.ALASS_RENAME_DONT_ASK_AGAIN, dlg)
+    dont_ask_again_box.setChecked(
+        app.config.get("disable_alass_rename_prompt", False)
+    )
+    layout.addWidget(dont_ask_again_box)
+
     buttons = QDialogButtonBox(
         QDialogButtonBox.StandardButton.Yes | QDialogButtonBox.StandardButton.No,
         dlg,
@@ -237,7 +244,11 @@ def _ask_rename_for_alass(app):
     timer.start(1000)
     result = dlg.exec()
     timer.stop()
-    return result == QDialog.DialogCode.Accepted, remember_box.isChecked()
+    return (
+        result == QDialog.DialogCode.Accepted,
+        remember_box.isChecked(),
+        dont_ask_again_box.isChecked(),
+    )
 
 
 def _ensure_alass_safe_paths(app, reference_path, subtitle_path):
@@ -249,12 +260,21 @@ def _ensure_alass_safe_paths(app, reference_path, subtitle_path):
     auto = app.config.get(
         "auto_rename_bracket_paths", DEFAULT_OPTIONS["auto_rename_bracket_paths"]
     )
+    disable_prompt = app.config.get(
+        "disable_alass_rename_prompt",
+        DEFAULT_OPTIONS["disable_alass_rename_prompt"],
+    )
+    if disable_prompt:
+        logger.info("ALASS rename prompt disabled, skipping rename prompt")
+        return True, ref, sub
     if not auto:
-        accepted, remember = _ask_rename_for_alass(app)
+        accepted, remember, dont_ask_again = _ask_rename_for_alass(app)
         if remember:
             update_config(app, "auto_rename_bracket_paths", True)
             if hasattr(app, "auto_rename_bracket_paths_action"):
                 app.auto_rename_bracket_paths_action.setChecked(True)
+        if dont_ask_again:
+            update_config(app, "disable_alass_rename_prompt", True)
         if not accepted:
             return True, ref, sub
     try:

--- a/main/sync_auto.py
+++ b/main/sync_auto.py
@@ -269,11 +269,11 @@ def _ensure_alass_safe_paths(app, reference_path, subtitle_path):
         return True, ref, sub
     if not auto:
         accepted, remember, dont_ask_again = _ask_rename_for_alass(app)
-        if remember:
+        if remember or (dont_ask_again and accepted):
             update_config(app, "auto_rename_bracket_paths", True)
             if hasattr(app, "auto_rename_bracket_paths_action"):
                 app.auto_rename_bracket_paths_action.setChecked(True)
-        if dont_ask_again:
+        if dont_ask_again and not accepted:
             update_config(app, "disable_alass_rename_prompt", True)
         if not accepted:
             return True, ref, sub

--- a/main/texts.py
+++ b/main/texts.py
@@ -4929,6 +4929,32 @@ ALASS_RENAME_ALWAYS = {
     "ur_PK": "ضرورت پڑنے پر فائلوں کے نام خودکار طور پر تبدیل کریں",
 }
 
+ALASS_RENAME_DONT_ASK_AGAIN = {
+    "en_US": "Don't ask again",
+    "es_ES": "No volver a preguntar",
+    "tr_TR": "Bir daha sorma",
+    "zh_CN": "不要再次询问",
+    "zh_TW": "不要再次詢問",
+    "ru_RU": "Больше не спрашивать",
+    "pl_PL": "Nie pytaj ponownie",
+    "uk_UA": "Більше не запитувати",
+    "ja_JP": "もう聞かない",
+    "ko_KR": "다시 묻지 않기",
+    "hi_IN": "फिर से न पूछें",
+    "bn_BD": "আবার জিজ্ঞেস করবেন না",
+    "it_IT": "Non chiedere più",
+    "fr_FR": "Ne plus demander",
+    "de_DE": "Nicht erneut fragen",
+    "pt_PT": "Não perguntar de novo",
+    "ar_SA": "لا تسأل مرة أخرى",
+    "vi_VN": "Đừng hỏi lại",
+    "fa_IR": "دیگه سوال نکن",
+    "id_ID": "Jangan tanya lagi",
+    "ms_MY": "Jangan tanya lagi",
+    "th_TH": "อย่า hỏiอีก",
+    "ur_PK": "دوبارہ نہ پوچھیں",
+}
+
 ALASS_RENAME_TIMER = {
     "en_US": "Skipping in {time} seconds...",
     "es_ES": "Omitiendo en {time} segundos...",


### PR DESCRIPTION
Added a “Don’t ask again” option to the ALASS rename prompt and persisted the choice in config so the prompt can be skipped in future sessions.

- Added a checkbox to the ALASS rename dialog
- Saved the preference through the existing config flow

### Motivation
This reduces repeated prompts for users who consistently choose to skip ALASS rename handling for bracketed paths.