### PR TITLE
feat: share embedded subtitle extraction with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ fully-featured CLI that never starts a Qt event loop or requires a display.
 assy-cli sync video.mkv subs.srt -o synced.srt --json
 # {"ok": true, "input": "subs.srt", "output": "synced.srt", "tool": "ffsubsync", ...}
 
+# Prefer a matching embedded subtitle stream as the sync reference
+assy-cli sync video.mkv subs.srt --embedded-subtitles
+
 # Shift a subtitle by 1.5 seconds
 assy-cli shift subs.srt 1500 -o shifted.srt
 
@@ -175,6 +178,9 @@ assy-cli batch --folder ./episodes --continue-on-error --json
 
 # Two-folder pairing with explicit output dir
 assy-cli batch --video-dir ./videos --subtitle-dir ./subs -o ./out --json
+
+# Enable embedded-subtitle references for every video in a batch
+assy-cli batch --folder ./episodes --embedded-subtitles
 
 # Pick a sync engine per call
 assy-cli sync video.mkv subs.srt -t alass
@@ -195,6 +201,11 @@ assy-cli config set sync_tool alass
 | `batch` | Process many pairs from `--folder`, `--video-dir`+`--subtitle-dir`, or repeated `--pair` |
 | `config` | `get` / `set` / `unset` / `list` / `path` for the user config JSON |
 | `version` | Print version |
+
+The `sync` and `batch` commands accept `--embedded-subtitles` and
+`--no-embedded-subtitles`. These flags override the selected tool's saved
+setting for that invocation. Without either flag, the saved setting and tool
+default are used.
 
 **Exit codes:** `0` success · `1` at least one sync failed · `2` usage or config error · `130` SIGINT.
 

--- a/main/cli.py
+++ b/main/cli.py
@@ -242,8 +242,26 @@ def _emit_json(obj) -> None:
     sys.stdout.flush()
 
 
+def _prepare_reference(reference, subtitle, output_path, tool, config, args):
+    from subtitle_extractor import prepare_sync_reference
+
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    prepared = prepare_sync_reference(
+        reference,
+        subtitle,
+        output_dir,
+        tool=tool,
+        config=config,
+        override=getattr(args, "embedded_subtitles", None),
+    )
+    for message in prepared.messages:
+        log.info("%s", message)
+    return prepared
+
+
 def cmd_sync(args) -> int:
-    from sync_core import run_sync
+    from subtitle_extractor import cleanup_extracted_subtitles
+    from sync_core import determine_output_path, run_sync
 
     config = _effective_config(args)
     _apply_common_overrides(config, args)
@@ -262,14 +280,23 @@ def cmd_sync(args) -> int:
     _ensure_ffmpeg()
     tool = config.get("sync_tool", "ffsubsync")
     callbacks = _build_callbacks(args.json)
-    result = run_sync(
-        args.video,
-        args.subtitle,
-        tool=tool,
-        output=args.output,
-        config=config,
-        callbacks=callbacks,
+    output_path = args.output or determine_output_path(
+        args.video, args.subtitle, config=config
     )
+    prepared = _prepare_reference(
+        args.video, args.subtitle, output_path, tool, config, args
+    )
+    try:
+        result = run_sync(
+            prepared.effective_reference,
+            args.subtitle,
+            tool=tool,
+            output=output_path,
+            config=config,
+            callbacks=callbacks,
+        )
+    finally:
+        cleanup_extracted_subtitles(prepared)
     if result.ok and result.output_path:
         _apply_output_encoding(args.subtitle, result.output_path, config)
 
@@ -330,7 +357,8 @@ def cmd_shift(args) -> int:
 
 
 def cmd_batch(args) -> int:
-    from sync_core import run_sync
+    from subtitle_extractor import cleanup_extracted_subtitles
+    from sync_core import determine_output_path, run_sync
     from pairing import pair_paths, pair_folder, pair_folders
     from constants import SUBTITLE_EXTENSIONS
 
@@ -424,14 +452,21 @@ def cmd_batch(args) -> int:
         callbacks = _build_callbacks(args.json, prefix=f"[{idx}/{total}] ")
         log.info("[%d/%d] %s + %s", idx, total, video, subtitle)
         tool = config.get("sync_tool", "ffsubsync")
-        result = run_sync(
-            video,
-            subtitle,
-            tool=tool,
-            output=None,
-            config=config,
-            callbacks=callbacks,
+        output_path = determine_output_path(video, subtitle, config=config)
+        prepared = _prepare_reference(
+            video, subtitle, output_path, tool, config, args
         )
+        try:
+            result = run_sync(
+                prepared.effective_reference,
+                subtitle,
+                tool=tool,
+                output=output_path,
+                config=config,
+                callbacks=callbacks,
+            )
+        finally:
+            cleanup_extracted_subtitles(prepared)
         if result.ok and result.output_path:
             _apply_output_encoding(subtitle, result.output_path, config)
             if mark and processed_mgr is not None:
@@ -597,6 +632,24 @@ def cmd_version(args) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    def add_embedded_subtitle_flags(parser):
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--embedded-subtitles",
+            dest="embedded_subtitles",
+            action="store_const",
+            const=True,
+            default=None,
+            help="Use a matching embedded subtitle stream as the sync reference",
+        )
+        group.add_argument(
+            "--no-embedded-subtitles",
+            dest="embedded_subtitles",
+            action="store_const",
+            const=False,
+            help="Do not use embedded subtitle streams",
+        )
+
     p = argparse.ArgumentParser(
         prog="assy-cli",
         description=(
@@ -656,6 +709,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Add custom suffix to the output filename",
         metavar="SUFFIX",
     )
+    add_embedded_subtitle_flags(s)
     s.add_argument("--json", action="store_true", help="Emit JSON result on stdout")
     s.set_defaults(handler=cmd_sync)
 
@@ -716,6 +770,7 @@ def build_parser() -> argparse.ArgumentParser:
     g.add_argument("--prefix", action="store_true")
     g.add_argument("--no-prefix", action="store_true")
     b.add_argument("--suffix", help="Add custom suffix to the output filename", metavar="SUFFIX")
+    add_embedded_subtitle_flags(b)
     skip_g = b.add_mutually_exclusive_group()
     skip_g.add_argument(
         "--skip-processed",

--- a/main/subtitle_extractor.py
+++ b/main/subtitle_extractor.py
@@ -1,11 +1,114 @@
 import os
+import shutil
+from dataclasses import dataclass, field
+from typing import Optional
+
 import texts
 from utils import create_process, detect_encoding
 from constants import (
+    DEFAULT_OPTIONS,
     FFMPEG_EXECUTABLE,
     FFPROBE_EXECUTABLE,
     EXTRACTABLE_SUBTITLE_EXTENSIONS,
+    SUBTITLE_EXTENSIONS,
+    SYNC_TOOLS,
 )
+
+
+@dataclass
+class SubtitleExtractionResult:
+    """Result of preparing a reference for subtitle synchronization."""
+
+    original_reference: str
+    effective_reference: str
+    enabled: bool = False
+    extracted_subtitle: Optional[str] = None
+    score: object = None
+    messages: list = field(default_factory=list)
+    cleanup_dir: Optional[str] = None
+
+
+def should_extract_subtitles(reference, tool, config, override=None):
+    """Return whether embedded-subtitle extraction applies to this sync."""
+    if os.path.splitext(reference)[1].lower() in SUBTITLE_EXTENSIONS:
+        return False
+
+    tool_info = SYNC_TOOLS.get(tool, {})
+    option = tool_info.get("options", {}).get("check_video_for_subtitles")
+    if not option:
+        return False
+    if override is not None:
+        return bool(override)
+    return bool(
+        config.get(
+            f"{tool}_check_video_for_subtitles",
+            option.get("default", False),
+        )
+    )
+
+
+def prepare_sync_reference(
+    reference,
+    subtitle,
+    output_dir,
+    *,
+    tool,
+    config,
+    override=None,
+):
+    """Prepare a video reference, optionally replacing it with an embedded subtitle.
+
+    Extraction failures are deliberately non-fatal: callers always receive the
+    original reference as a fallback.
+    """
+    enabled = should_extract_subtitles(reference, tool, config, override)
+    result = SubtitleExtractionResult(
+        original_reference=reference,
+        effective_reference=reference,
+        enabled=enabled,
+    )
+    if not enabled:
+        return result
+
+    result.messages.append(texts.CHECKING_VIDEO_FOR_EMBEDDED_SUBTITLES)
+    if not config.get(
+        "keep_extracted_subtitles",
+        DEFAULT_OPTIONS["keep_extracted_subtitles"],
+    ):
+        result.cleanup_dir = os.path.join(
+            output_dir, "extracted_subtitles_" + os.path.basename(reference)
+        )
+    try:
+        extracted, score, messages = extract_subtitles(reference, subtitle, output_dir)
+        result.messages.extend(messages)
+        result.score = score
+        if extracted:
+            result.extracted_subtitle = extracted
+            result.effective_reference = extracted
+            result.messages.append(
+                texts.EXTRACTION_SELECTED_WITH_TIMESTAMP.format(
+                    filename=os.path.basename(extracted), score=score
+                )
+            )
+        else:
+            result.messages.append(texts.EXTRACTION_NO_COMPATIBLE_SUBTITLES)
+    except Exception as exc:
+        result.messages.append(texts.EXTRACTION_FAILED_PREFIX + str(exc))
+    except BaseException:
+        cleanup_extracted_subtitles(result)
+        raise
+    return result
+
+
+def cleanup_extracted_subtitles(result):
+    """Remove temporary extraction output when the result requests cleanup."""
+    if not result or not result.cleanup_dir:
+        return
+    try:
+        if os.path.isdir(result.cleanup_dir):
+            shutil.rmtree(result.cleanup_dir)
+    finally:
+        result.cleanup_dir = None
 
 
 def parse_timestamps(subtitle_file):

--- a/main/sync_auto.py
+++ b/main/sync_auto.py
@@ -25,7 +25,10 @@ from sync_core import (
     shorten_progress_bar,
 )
 from subtitle_converter import convert_to_srt
-from subtitle_extractor import extract_subtitles
+from subtitle_extractor import (
+    cleanup_extracted_subtitles,
+    prepare_sync_reference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -661,96 +664,39 @@ def start_sync_process(app):
                 subtitle_path != original_sub_path and subtitle_path is not None
             )
 
-            # Then check for embedded subtitles in video if applicable
-            ref_ext = os.path.splitext(original_ref_path)[1].lower()
-            is_video_ref = ref_ext not in SUBTITLE_EXTENSIONS
-            check_video_subs = is_video_ref and app.config.get(
-                f"{tool}_check_video_for_subtitles",
-                SYNC_TOOLS[tool]
-                .get("options", {})
-                .get("check_video_for_subtitles", {})
-                .get("default", False),
-            )
-            extracted_subtitle_path, extracted_folder_to_clean = None, None
-            if check_video_subs:
-                append_log(
-                    app, texts.CHECKING_VIDEO_FOR_EMBEDDED_SUBTITLES, COLORS["GREY"]
-                )
-                extraction_result, extraction_done, log_lock = (
-                    [None, None, []],
-                    threading.Event(),
-                    threading.Lock(),
-                )
+            # Prepare the reference through the shared GUI/CLI extraction workflow.
+            extraction_result, extraction_done = [None], threading.Event()
 
+            if subtitle_path:
                 def run_extraction():
                     try:
-                        result = extract_subtitles(
-                            original_ref_path, subtitle_path, output_dir
+                        extraction_result[0] = prepare_sync_reference(
+                            original_ref_path,
+                            subtitle_path,
+                            output_dir,
+                            tool=tool,
+                            config=app.config,
                         )
-                        extraction_result[0], extraction_result[1] = (
-                            result[0],
-                            result[1],
-                        )
-                        with log_lock:
-                            extraction_result[2].extend(result[2])
                     except Exception as e:
                         logger.exception(f"Extraction failed: {e}")
-                        with log_lock:
-                            extraction_result[2].append(
-                                texts.EXTRACTION_FAILED_PREFIX + str(e)
-                            )
                     finally:
                         extraction_done.set()
 
                 threading.Thread(target=run_extraction, daemon=True).start()
-                last_log_count = 0
                 while not extraction_done.is_set():
-                    with log_lock:
-                        while last_log_count < len(extraction_result[2]):
-                            append_log(
-                                app,
-                                f"{extraction_result[2][last_log_count]}",
-                                COLORS["GREY"],
-                            )
-                            last_log_count += 1
                     QApplication.processEvents()
                     time.sleep(0.05)
-                with log_lock:
-                    for i in range(last_log_count, len(extraction_result[2])):
-                        append_log(app, f"{extraction_result[2][i]}", COLORS["GREY"])
-                extracted_subtitle_path, extraction_score = (
-                    extraction_result[0],
-                    extraction_result[1],
-                )
-                if extracted_subtitle_path:
-                    filename = os.path.basename(extracted_subtitle_path)
-                    append_log(
-                        app,
-                        texts.EXTRACTION_SELECTED_WITH_TIMESTAMP.format(
-                            filename=filename, score=extraction_score
-                        ),
-                        COLORS["BLUE"],
-                    )
-                    if not app.config.get(
-                        "keep_extracted_subtitles",
-                        DEFAULT_OPTIONS["keep_extracted_subtitles"],
-                    ):
-                        extracted_folder_to_clean = os.path.dirname(
-                            extracted_subtitle_path
-                        )
-                else:
-                    append_log(
-                        app, texts.EXTRACTION_NO_COMPATIBLE_SUBTITLES, COLORS["ORANGE"]
-                    )
+                for message in extraction_result[0].messages:
+                    append_log(app, f"{message}", COLORS["GREY"])
 
+            extraction = extraction_result[0]
             reference_to_process = (
-                extracted_subtitle_path
-                if extracted_subtitle_path
-                else original_ref_path
+                extraction.effective_reference if extraction else original_ref_path
             )
             reference_path = convert_if_needed(reference_to_process)
             current_item_idx += 1
             if not reference_path or not subtitle_path:
+                cleanup_extracted_subtitles(extraction)
                 if app.batch_mode_enabled and total_items > 1:
                     batch_fail_count += 1
                     failed_pairs.append(
@@ -818,17 +764,19 @@ def start_sync_process(app):
                 if hasattr(app, "_batch_state") and app._batch_state.get(
                     "should_cancel", False
                 ):
-                    cleanup_files(converted_files_to_clean, extracted_folder_to_clean)
+                    cleanup_files(converted_files_to_clean)
+                    cleanup_extracted_subtitles(extraction)
                     return
                 ok = handle_completion(app, ok, out, original_sub_path)
                 if ok:
                     batch_success_count += 1
-                    cleanup_files(converted_files_to_clean, extracted_folder_to_clean)
                 else:
                     batch_fail_count += 1
                     failed_pairs.append(
                         (original_idx, original_ref_path, original_sub_path)
                     )
+                cleanup_files(converted_files_to_clean)
+                cleanup_extracted_subtitles(extraction)
                 update_progress(
                     app,
                     int((original_idx + 1) * 100 / total_items),
@@ -847,8 +795,8 @@ def start_sync_process(app):
 
             def single_completion_handler(ok, out):
                 ok = handle_completion(app, ok, out, original_sub_path)
-                if ok:
-                    cleanup_files(converted_files_to_clean, extracted_folder_to_clean)
+                cleanup_files(converted_files_to_clean)
+                cleanup_extracted_subtitles(extraction)
                 # Pass sync tracking callback to be called after success message but before saved to
                 post_success_cb = (
                     (lambda: _mark_item_as_processed(app, original_ref_path))


### PR DESCRIPTION
## Summary

This PR shares the embedded-subtitle extraction workflow between the GUI and CLI.

Previously, extraction was orchestrated only by the GUI. The CLI now uses the same Qt-free preprocessing workflow for individual and batch synchronization.

## Changes

- Added a common embedded-subtitle preprocessing API.
- Reused the common workflow in both GUI and CLI paths.
- Added CLI options:
  - `--embedded-subtitles`
  - `--no-embedded-subtitles`
- Preserved per-tool configuration and defaults when neither flag is provided.
- Added fallback to the original video when extraction is unavailable or fails.
- Centralized temporary extracted-subtitle cleanup.
- Preserved JSON output on stdout while sending extraction logs to stderr.
- Updated CLI documentation and examples.

## Examples

```bash
assy-cli sync video.mkv subtitle.srt \
  --tool alass \
  --embedded-subtitles
```
```bash
assy-cli batch --folder ./episodes \
  --tool alass \
  --embedded-subtitles
```